### PR TITLE
Fix insecure keys

### DIFF
--- a/chains/ethereum/chain.go
+++ b/chains/ethereum/chain.go
@@ -29,7 +29,7 @@ func InitializeChain(chainCfg *core.ChainConfig) (*Chain, error) {
 		return nil, err
 	}
 
-	kpI, err := keystore.KeypairFromAddress(cfg.from, keystore.EthChain, cfg.keystorePath, false)
+	kpI, err := keystore.KeypairFromAddress(cfg.from, keystore.EthChain, cfg.keystorePath, chainCfg.Insecure)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/chainbridge/main.go
+++ b/cmd/chainbridge/main.go
@@ -76,6 +76,7 @@ func init() {
 	app.Usage = "ChainBridge V2"
 	app.Author = "ChainSafe Systems 2019"
 	app.Version = "0.0.1"
+	app.EnableBashCompletion = true
 	app.Commands = []cli.Command{
 		accountCommand,
 	}
@@ -120,8 +121,10 @@ func run(ctx *cli.Context) error {
 	}
 
 	var ks string
+	var insecure bool
 	if key := ctx.GlobalString(TestKeyFlag.Name); key != "" {
-		ks = ctx.GlobalString(TestKeyFlag.Name)
+		ks = key
+		insecure = true
 	} else {
 		ks = cfg.keystorePath
 	}
@@ -136,6 +139,7 @@ func run(ctx *cli.Context) error {
 				Endpoint:     chain.Endpoint,
 				From:         chain.From,
 				KeystorePath: ks,
+				Insecure:     insecure,
 				Opts:         chain.Opts,
 			})
 		} else if chain.Type == "substrate" {
@@ -144,6 +148,7 @@ func run(ctx *cli.Context) error {
 				Endpoint:     chain.Endpoint,
 				From:         chain.From,
 				KeystorePath: ks,
+				Insecure:     insecure,
 				Opts:         chain.Opts,
 			})
 		} else {

--- a/core/chain.go
+++ b/core/chain.go
@@ -20,5 +20,6 @@ type ChainConfig struct {
 	Endpoint     string            // url for rpc endpoint
 	From         string            // address of key to use
 	KeystorePath string            // Location of key files
+	Insecure     bool              // Indicated whether the test keyring should be used
 	Opts         map[string]string // Per chain options
 }


### PR DESCRIPTION
Previous updates to the keystore didn't include a way to pass the insecure flag when loading keys, this fixes that.