### PR TITLE
CI Cleanup & Substrate Prep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ keys/
 # nodejs
 node_modules/
 
-centrifuge-chain/
+./centrifuge-chain
 
 /contracts
 abi/

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ node_modules/
 ./centrifuge-chain
 
 /contracts
+/on-chain/evm-contracts/bindings
 abi/

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ jobs:
       go: 1.13.x
       name: "Golang-ci Linter"
       script:
+        - make license-check
         - make bindings
         - make lint
-        - make license-check
 
     - language: go
       go: 1.13.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
       script:
         - make bindings
         - make lint
+        - make license-check
 
     - language: go
       go: 1.13.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,14 @@ jobs:
       go: 1.13.x
       name: "Golang-ci Linter"
       script:
+        - make bindings
         - make lint
 
     - language: go
       go: 1.13.x
       name: "Run Go tests"
       script:
+        - make bindings
         - SILENT=true make start_eth
         - make deploy_eth
         - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
         - make bindings
         - SILENT=true make start_eth
         - make deploy_eth
+        - ./scripts/centrifuge/run_chain_ci.sh
         - make test
 
     - language: node_js

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,6 @@ lint:
 	fi;
 	./bin/golangci-lint run ./... --timeout 5m0s
 
-ci-lint: bindings lint
-
 build: bindings
 	@echo "  >  \033[32mBuilding binary...\033[0m "
 	cd cmd/chainbridge && env GOARCH=amd64 go build -o ../../build/chainbridge

--- a/Makefile
+++ b/Makefile
@@ -26,21 +26,19 @@ get_lint:
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s latest
 
 .PHONY: lint
-lint: bindings
+lint:
 	if [ ! -f ./bin/golangci-lint ]; then \
 		$(MAKE) get_lint; \
 	fi;
 	./bin/golangci-lint run ./... --timeout 5m0s
 
-fmt:
-	@echo "  >  \033[32mFormatting project...\033[0m "
-	gofmt -s -w .
+ci-lint: bindings lint
 
 build: bindings
 	@echo "  >  \033[32mBuilding binary...\033[0m "
 	cd cmd/chainbridge && env GOARCH=amd64 go build -o ../../build/chainbridge
 
-run: build bindings
+run: build
 	@echo "  >  \033[32mRunning bridge...\033[0m "
 	./build/chainbridge
 
@@ -48,7 +46,7 @@ install: bindings
 	@echo "  >  \033[32mInstalling bridge...\033[0m "
 	cd cmd/chainbridge && go install
 
-test: bindings
+test:
 	@echo "  >  \033[32mRunning tests...\033[0m "
 	./scripts/test.sh
 	

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
 PROJECTNAME=$(shell basename "$(PWD)")
-GOLANGCI := $(shell go env GOPATH)
-GOLANGCI_BIN := $(GOLANGCI)/bin
-GOLANGCI := $(GOLANGCI)/bin/golangci-lint
 
 CENT_EMITTER_ADDR?=0x1
 CENT_CHAIN_ID?=0x1
@@ -24,14 +21,14 @@ get:
 	go mod tidy && go mod download
 
 get_lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOLANGCI_BIN) v1.24.0
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s latest
 
 .PHONY: lint
 lint:
-	if [ ! -f $(GOLANGCI) ]; then \
+	if [ ! -f ./bin/golangci-lint ]; then \
 		$(MAKE) get_lint; \
 	fi;
-	$(GOLANGCI) run ./... --timeout 5m0s
+	./bin/golangci-lint run ./... --timeout 5m0s
 
 build: bindings
 	@echo "  >  \033[32mBuilding binary...\033[0m "

--- a/on-chain/evm-contracts/scripts/cli/transfer.js
+++ b/on-chain/evm-contracts/scripts/cli/transfer.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright 2020 ChainSafe Systems
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
 const ethers = require('ethers');
 const constants = require('./constants');
 

--- a/scripts/centrifuge/run_chain_ci.sh
+++ b/scripts/centrifuge/run_chain_ci.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright 2020 ChainSafe Systems
+# SPDX-License-Identifier: LGPL-3.0-only
+
+S3_URL="https://centchain.nyc3.digitaloceanspaces.com"
+CENT_CHAIN_COMMIT="51f7a9dfbf51590dceb457da0a8a05c814cbabef"
+CENT_CHAIN_BUILD_NUM="151844930"
+CENT_CHAIN_BRANCH="david/bridge-module"
+
+set -eux
+
+rm -rf ./centrifuge-chain
+
+wget $S3_URL/$CENT_CHAIN_COMMIT-$CENT_CHAIN_BUILD_NUM/centrifuge-chain
+
+chmod a+x ./centrifuge-chain
+
+rm -rf $HOME/.local/share/centrifuge-chain/
+
+./centrifuge-chain --dev --alice &


### PR DESCRIPTION
- Adds centrifuge-chain to CI tests (tests to come in #134)
- Removes unused make commands
- Reduce implicit usage of `make bindings` (removed from `make lint` and `make run`)
- Adds license check to CI (`make license-check`)
- Update git ignore