### PR TITLE
Add Centrifuge Deposit Support

### DIFF
--- a/on-chain/evm-contracts/contracts/Bridge.sol
+++ b/on-chain/evm-contracts/contracts/Bridge.sol
@@ -53,8 +53,17 @@ contract Bridge {
         bytes   _data;
     }
 
+    struct CentrifugeDepositRecord {
+        address   _originChainTokenAddress;
+        address   _originChainHandlerAddress;
+        uint      _destinationChainID;
+        address   _destinationChainHandlerAddress;
+        address   _destinationRecipientAddress;
+        bytes32   _metaDataHash;
+    }
+
     struct DepositProposal {
-        uint _originChainID;
+        uint _destinationChainID;
         uint _depositID;
         bytes32 _dataHash;
         mapping(address => bool) _votes;
@@ -79,22 +88,25 @@ contract Bridge {
     mapping(uint => mapping(uint => ERC20DepositRecord)) public _erc20DepositRecords;
     // chainID => depositID => ERC721DepositRecord
     mapping(uint => mapping(uint => ERC721DepositRecord)) public _erc721DepositRecords;
+    // chainID => depositID => CentrifugeDepositRecord
+    mapping(uint => mapping(uint => CentrifugeDepositRecord)) public _centrifugeDepositRecords;
     // ChainId => DepositID => Proposal
     mapping(uint => mapping(uint => DepositProposal)) public _depositProposals;
 
-    event GenericDeposited(uint indexed depositID);
-    event ERC20Deposited(uint indexed depositID);
-    event ERC721Deposited(uint indexed depositID);
-    event DepositProposalCreated(uint indexed originChainID, uint indexed depositID, bytes32 indexed dataHash);
-    event DepositProposalVote(uint indexed originChainID, uint indexed depositID, Vote indexed vote, DepositProposalStatus status);
-    event DepositProposalFinalized(uint indexed originChainID, uint indexed depositID);
+    event GenericDeposited(uint indexed destinationChainID, uint indexed depositID);
+    event ERC20Deposited(uint indexed destinationChainID, uint indexed depositID);
+    event ERC721Deposited(uint indexed destinationChainID, uint indexed depositID);
+    event CentrifugeDeposited(uint indexed destinationChainID, uint indexed depositID);
+    event DepositProposalCreated(uint indexed destinationChainID, uint indexed depositID, bytes32 indexed dataHash);
+    event DepositProposalVote(uint indexed destinationChainID, uint indexed depositID, Vote indexed vote, DepositProposalStatus status);
+    event DepositProposalFinalized(uint indexed destinationChainID, uint indexed depositID);
     event RelayerThresholdProposalCreated(uint indexed proposedValue);
     event RelayerThresholdProposalVote(Vote vote);
     event RelayerThresholdChanged(uint indexed newThreshold);
 
     modifier _onlyRelayers() {
         IRelayer relayerContract = IRelayer(_relayerContract);
-        require(relayerContract.isRelayer(msg.sender));
+        require(relayerContract.isRelayer(msg.sender), "sender must be a relayer");
         _;
     }
 
@@ -107,13 +119,13 @@ contract Bridge {
         return _relayerThreshold;
     }
 
-    function getDepositCount(uint originChainID) public view returns (uint) {
-        return _depositCounts[originChainID];
+    function getDepositCount(uint destinationChainID) public view returns (uint) {
+        return _depositCounts[destinationChainID];
     }
 
-    function getGenericDepositRecord(uint originChainID, uint depositID) public view returns (
+    function getGenericDepositRecord(uint destinationChainID, uint depositID) public view returns (
         address, address, uint, address, address, bytes memory) {
-        GenericDepositRecord memory genericDepositRecord = _genericDepositRecords[originChainID][depositID];
+        GenericDepositRecord memory genericDepositRecord = _genericDepositRecords[destinationChainID][depositID];
         return (
             genericDepositRecord._originChainTokenAddress,
             genericDepositRecord._originChainHandlerAddress,
@@ -123,9 +135,9 @@ contract Bridge {
             genericDepositRecord._data);
     }
 
-    function getERC20DepositRecord(uint originChainID, uint depositID) public view returns (
+    function getERC20DepositRecord(uint destinationChainID, uint depositID) public view returns (
         address, address, uint, address, address, uint) {
-        ERC20DepositRecord memory erc20DepositRecord = _erc20DepositRecords[originChainID][depositID];
+        ERC20DepositRecord memory erc20DepositRecord = _erc20DepositRecords[destinationChainID][depositID];
         return (
             erc20DepositRecord._originChainTokenAddress,
             erc20DepositRecord._originChainHandlerAddress,
@@ -135,9 +147,9 @@ contract Bridge {
             erc20DepositRecord._amount);
     }
 
-    function getERC721DepositRecord(uint originChainID, uint depositID) public view returns (
+    function getERC721DepositRecord(uint destinationChainID, uint depositID) public view returns (
         address, address, uint, address, address, uint, bytes memory) {
-        ERC721DepositRecord memory erc721DepositRecord = _erc721DepositRecords[originChainID][depositID];
+        ERC721DepositRecord memory erc721DepositRecord = _erc721DepositRecords[destinationChainID][depositID];
         return (
             erc721DepositRecord._originChainTokenAddress,
             erc721DepositRecord._originChainHandlerAddress,
@@ -146,6 +158,18 @@ contract Bridge {
             erc721DepositRecord._destinationRecipientAddress,
             erc721DepositRecord._tokenID,
             erc721DepositRecord._data);
+    }
+
+    function getCentrifugeDepositRecord(uint destinationChainID, uint depositID) public view returns (
+        address, address, uint, address, address, bytes32) {
+        CentrifugeDepositRecord memory centrifugeDepositRecord = _centrifugeDepositRecords[destinationChainID][depositID];
+        return (
+            centrifugeDepositRecord._originChainTokenAddress,
+            centrifugeDepositRecord._originChainHandlerAddress,
+            centrifugeDepositRecord._destinationChainID,
+            centrifugeDepositRecord._destinationChainHandlerAddress,
+            centrifugeDepositRecord._destinationRecipientAddress,
+            centrifugeDepositRecord._metaDataHash);
     }
 
     function getCurrentRelayerThresholdProposal() public view returns (
@@ -157,11 +181,11 @@ contract Bridge {
             _relayerThresholdProposalStatusStrings[uint(_currentRelayerThresholdProposal._status)]);
     }
 
-    function getDepositProposal(uint originChainID, uint depositID) public view returns (
+    function getDepositProposal(uint destinationChainID, uint depositID) public view returns (
         uint, uint, bytes32, uint, uint, string memory) {
-        DepositProposal memory depositProposal = _depositProposals[originChainID][depositID];
+        DepositProposal memory depositProposal = _depositProposals[destinationChainID][depositID];
         return (
-            depositProposal._originChainID,
+            depositProposal._destinationChainID,
             depositProposal._depositID,
             depositProposal._dataHash,
             depositProposal._numYes,
@@ -169,8 +193,8 @@ contract Bridge {
             _depositProposalStatusStrings[uint(depositProposal._status)]);
     }
 
-    function hasVoted(uint originChainID, uint depositID, address relayerAddress) public view returns (bool) {
-        return _depositProposals[originChainID][depositID]._votes[relayerAddress];
+    function hasVoted(uint destinationChainID, uint depositID, address relayerAddress) public view returns (bool) {
+        return _depositProposals[destinationChainID][depositID]._votes[relayerAddress];
     }
 
     function depositGeneric(
@@ -189,7 +213,7 @@ contract Bridge {
             data
         );
 
-        emit GenericDeposited(depositID);
+        emit GenericDeposited(destinationChainID, depositID);
     }
 
     function depositGeneric(
@@ -211,7 +235,7 @@ contract Bridge {
             data
         );
 
-        emit GenericDeposited(depositID);
+        emit GenericDeposited(destinationChainID, depositID);
     }
 
     function depositERC20(
@@ -236,7 +260,7 @@ contract Bridge {
             amount
         );
 
-        emit ERC20Deposited(depositID);
+        emit ERC20Deposited(destinationChainID, depositID);
     }
 
     function depositERC721(
@@ -263,17 +287,39 @@ contract Bridge {
             data
         );
 
-        emit ERC721Deposited(depositID);
+        emit ERC721Deposited(destinationChainID, depositID);
     }
 
-    function createDepositProposal(uint originChainID, uint depositID, bytes32 dataHash) public _onlyRelayers {
-        require(_depositProposals[originChainID][depositID]._status == DepositProposalStatus.Inactive ||
-        _depositProposals[originChainID][depositID]._status == DepositProposalStatus.Denied, "this proposal is either currently active or has already been passed/transferred");
+    function depositCentrifuge(
+        address originChainContractAddress,
+        address originChainHandlerAddress,
+        uint    destinationChainID,
+        address destinationChainHandlerAddress,
+        address destinationRecipientAddress,
+        bytes32 metaDataHash
+    ) public {
+        uint depositID = ++_depositCounts[destinationChainID];
+
+        _centrifugeDepositRecords[destinationChainID][depositID] = CentrifugeDepositRecord(
+            originChainContractAddress,
+            originChainHandlerAddress,
+            destinationChainID,
+            destinationChainHandlerAddress,
+            destinationRecipientAddress,
+            metaDataHash
+        );
+
+        emit CentrifugeDeposited(destinationChainID, depositID);
+    }
+
+    function createDepositProposal(uint destinationChainID, uint depositID, bytes32 dataHash) public _onlyRelayers {
+        require(_depositProposals[destinationChainID][depositID]._status == DepositProposalStatus.Inactive ||
+        _depositProposals[destinationChainID][depositID]._status == DepositProposalStatus.Denied, "this proposal is either currently active or has already been passed/transferred");
 
         // If _depositThreshold is set to 1, then auto finalize
         if (_relayerThreshold <= 1) {
-            _depositProposals[originChainID][depositID] = DepositProposal({
-                _originChainID: originChainID,
+            _depositProposals[destinationChainID][depositID] = DepositProposal({
+                _destinationChainID: destinationChainID,
                 _depositID: depositID,
                 _dataHash: dataHash,
                 _numYes: 1, // Creator always votes in favour
@@ -281,8 +327,8 @@ contract Bridge {
                 _status: DepositProposalStatus.Passed
                 });
         } else {
-            _depositProposals[originChainID][depositID] = DepositProposal({
-                _originChainID: originChainID,
+            _depositProposals[destinationChainID][depositID] = DepositProposal({
+                _destinationChainID: destinationChainID,
                 _depositID: depositID,
                 _dataHash: dataHash,
                 _numYes: 1, // Creator always votes in favour
@@ -292,13 +338,13 @@ contract Bridge {
         }
 
         // Creator always votes in favour
-        _depositProposals[originChainID][depositID]._votes[msg.sender] = true;
+        _depositProposals[destinationChainID][depositID]._votes[msg.sender] = true;
 
-        emit DepositProposalCreated(originChainID, depositID, dataHash);
+        emit DepositProposalCreated(destinationChainID, depositID, dataHash);
     }
 
-    function voteDepositProposal(uint originChainID, uint depositID, Vote vote) public _onlyRelayers {
-        DepositProposal storage depositProposal = _depositProposals[originChainID][depositID];
+    function voteDepositProposal(uint destinationChainID, uint depositID, Vote vote) public _onlyRelayers {
+        DepositProposal storage depositProposal = _depositProposals[destinationChainID][depositID];
 
         require(depositProposal._status != DepositProposalStatus.Inactive, "proposal is not active");
         require(depositProposal._status == DepositProposalStatus.Active, "proposal has been finalized");
@@ -316,17 +362,17 @@ contract Bridge {
         // Todo: Edge case if relayer threshold changes?
         if (depositProposal._numYes >= _relayerThreshold) {
             depositProposal._status = DepositProposalStatus.Passed;
-            emit DepositProposalFinalized(originChainID, depositID);
+            emit DepositProposalFinalized(destinationChainID, depositID);
         } else if (_relayerContract.getTotalRelayers().sub(depositProposal._numNo) < _relayerThreshold) {
             depositProposal._status = DepositProposalStatus.Denied;
-            emit DepositProposalFinalized(originChainID, depositID);
+            emit DepositProposalFinalized(destinationChainID, depositID);
         }
 
-        emit DepositProposalVote(originChainID, depositID, vote, depositProposal._status);
+        emit DepositProposalVote(destinationChainID, depositID, vote, depositProposal._status);
     }
 
-    function executeDepositProposal(uint originChainID, uint depositID, address destinationChainHandlerAddress, bytes memory data) public {
-        DepositProposal storage depositProposal = _depositProposals[originChainID][depositID];
+    function executeDepositProposal(uint destinationChainID, uint depositID, address destinationChainHandlerAddress, bytes memory data) public {
+        DepositProposal storage depositProposal = _depositProposals[destinationChainID][depositID];
 
         require(depositProposal._status != DepositProposalStatus.Inactive, "proposal is not active");
         require(depositProposal._status == DepositProposalStatus.Passed, "proposal was not passed or has already been transferred");

--- a/on-chain/evm-contracts/contracts/handlers/CentrifugeAssetHandler.sol
+++ b/on-chain/evm-contracts/contracts/handlers/CentrifugeAssetHandler.sol
@@ -21,7 +21,7 @@ contract CentrifugeAssetHandler is IDepositHandler {
 
     function depositAsset(bytes32 metaDataHash) public _onlyBridge {
         require(_assetDepositStatuses[metaDataHash] == AssetDepositStatus.Uninitialized,
-        "asset has already been initialized and cannot be changed");
+        "asset has already been deposited and cannot be changed");
         _assetDepositStatuses[metaDataHash] = AssetDepositStatus.Active;
     }
 

--- a/on-chain/evm-contracts/contracts/handlers/CentrifugeAssetHandler.sol
+++ b/on-chain/evm-contracts/contracts/handlers/CentrifugeAssetHandler.sol
@@ -1,0 +1,38 @@
+pragma solidity 0.6.4;
+
+import "../interfaces/IDepositHandler.sol";
+
+contract CentrifugeAssetHandler is IDepositHandler {
+    address public _bridgeAddress;
+
+    enum AssetDepositStatus { Uninitialized, Active, Confirmed }
+
+    // metaDataHash => AssetDepositStatus
+    mapping(bytes32 => AssetDepositStatus) _assetDepositStatuses;
+
+    modifier _onlyBridge() {
+        require(msg.sender == _bridgeAddress, "sender must be bridge contract");
+        _;
+    }
+
+    constructor(address bridgeAddress) public {
+        _bridgeAddress = bridgeAddress;
+    }
+
+    function depositAsset(bytes32 metaDataHash) public _onlyBridge {
+        require(_assetDepositStatuses[metaDataHash] == AssetDepositStatus.Uninitialized,
+        "asset has already been initialized and cannot be changed");
+        _assetDepositStatuses[metaDataHash] = AssetDepositStatus.Active;
+    }
+
+    function executeDeposit(bytes memory data) public override {
+        bytes32 metaDataHash;
+
+        assembly {
+            metaDataHash := mload(add(data, 0x20))
+        }
+
+        require(_assetDepositStatuses[metaDataHash] == AssetDepositStatus.Active, "asset hasn't been deposited");
+        _assetDepositStatuses[metaDataHash] = AssetDepositStatus.Confirmed;
+    }
+}

--- a/on-chain/evm-contracts/contracts/handlers/CentrifugeAssetHandler.sol
+++ b/on-chain/evm-contracts/contracts/handlers/CentrifugeAssetHandler.sol
@@ -32,7 +32,7 @@ contract CentrifugeAssetHandler is IDepositHandler {
             metaDataHash := mload(add(data, 0x20))
         }
 
-        require(_assetDepositStatuses[metaDataHash] == AssetDepositStatus.Active, "asset hasn't been deposited");
+        require(_assetDepositStatuses[metaDataHash] == AssetDepositStatus.Active, "asset hasn't been deposited or has already been finalized");
         _assetDepositStatuses[metaDataHash] = AssetDepositStatus.Confirmed;
     }
 }

--- a/on-chain/evm-contracts/contracts/interfaces/ICentrifugeAssetHandler.sol
+++ b/on-chain/evm-contracts/contracts/interfaces/ICentrifugeAssetHandler.sol
@@ -1,0 +1,6 @@
+pragma solidity 0.6.4;
+
+interface ICentrifugeAssetHandler {
+    function depositAsset(bytes32 metaDataHash) external;
+    function executeDeposit(bytes calldata data) external;
+}

--- a/on-chain/evm-contracts/test/chainBridge/createDepositProposal.js
+++ b/on-chain/evm-contracts/test/chainBridge/createDepositProposal.js
@@ -83,7 +83,7 @@ contract('Bridge - [createDepositProposal with relayerThreshold = 1]', async (ac
 
     it('depositProposal can be created', async () => {
         truffleAssert.passes(await BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
@@ -92,7 +92,7 @@ contract('Bridge - [createDepositProposal with relayerThreshold = 1]', async (ac
 
     it('Only relayers should be able to create a deposit proposal', async () => {
         await truffleAssert.reverts(BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainDepositerAddress }
@@ -101,7 +101,7 @@ contract('Bridge - [createDepositProposal with relayerThreshold = 1]', async (ac
 
     it('depositProposal is created with expected values', async () => {
         const expectedDepositProposal = {
-            _originChainID: originChainID,
+            _destinationChainID: destinationChainID,
             _depositID: expectedDepositID,
             _dataHash: dataHash,
             _numYes: 1,
@@ -110,13 +110,13 @@ contract('Bridge - [createDepositProposal with relayerThreshold = 1]', async (ac
         };
 
         await BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
         );
 
-        const depositProposal = await BridgeInstance._depositProposals.call(originChainID, expectedDepositID);
+        const depositProposal = await BridgeInstance._depositProposals.call(destinationChainID, expectedDepositID);
         for (const expectedProperty of Object.keys(expectedDepositProposal)) {
             // Testing all expected object properties
             assert.property(depositProposal, expectedProperty, `property: ${expectedProperty} does not exist in depositRecord`);
@@ -132,14 +132,14 @@ contract('Bridge - [createDepositProposal with relayerThreshold = 1]', async (ac
 
     it("depositProposal shouldn't be created if it doesn't have Inactive or Denied status", async () => {
         await truffleAssert.passes(BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
         ));
 
         await truffleAssert.reverts(BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
@@ -148,25 +148,25 @@ contract('Bridge - [createDepositProposal with relayerThreshold = 1]', async (ac
 
     it('originChainRelayerAddress should be marked as vote for proposal', async () => {
         await BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
         );
-        const hasVoted = await BridgeInstance.hasVoted(originChainID, expectedDepositID, originChainRelayerAddress);
+        const hasVoted = await BridgeInstance.hasVoted(destinationChainID, expectedDepositID, originChainRelayerAddress);
         assert.isTrue(hasVoted);
     });
 
     it('DepositProposalCreated event is fired with expected value', async () => {
         const proposalTx = await BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
         );
 
         truffleAssert.eventEmitted(proposalTx, 'DepositProposalCreated', (event) => {
-            return event.originChainID.toNumber() === originChainID &&
+            return event.destinationChainID.toNumber() === destinationChainID &&
                 event.depositID.toNumber() === expectedDepositID &&
                 event.dataHash === dataHash
         });
@@ -174,7 +174,7 @@ contract('Bridge - [createDepositProposal with relayerThreshold = 1]', async (ac
 
     it('getDepositProposal should return correct values in expected order', async () => {
         const expectedDepositProposal = {
-            _originChainID: originChainID,
+            _destinationChainID: destinationChainID,
             _depositID: expectedDepositID,
             _dataHash: dataHash,
             _numYes: 1,
@@ -183,7 +183,7 @@ contract('Bridge - [createDepositProposal with relayerThreshold = 1]', async (ac
         };
 
         await BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
@@ -271,7 +271,7 @@ contract('Bridge - [createDepositProposal with relayerThreshold > 1]', async (ac
 
     it('depositProposal can be created', async () => {
         truffleAssert.passes(await BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
@@ -280,7 +280,7 @@ contract('Bridge - [createDepositProposal with relayerThreshold > 1]', async (ac
 
     it('Only relayers should be able to create a deposit proposal', async () => {
         await truffleAssert.reverts(BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainDepositerAddress }
@@ -289,7 +289,7 @@ contract('Bridge - [createDepositProposal with relayerThreshold > 1]', async (ac
 
     it('depositProposal is created with expected values', async () => {
         const expectedDepositProposal = {
-            _originChainID: originChainID,
+            _destinationChainID: destinationChainID,
             _depositID: expectedDepositID,
             _dataHash: dataHash,
             _numYes: 1,
@@ -298,13 +298,13 @@ contract('Bridge - [createDepositProposal with relayerThreshold > 1]', async (ac
         };
 
         await BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
         );
 
-        const depositProposal = await BridgeInstance._depositProposals.call(originChainID, expectedDepositID);
+        const depositProposal = await BridgeInstance._depositProposals.call(destinationChainID, expectedDepositID);
         for (const expectedProperty of Object.keys(expectedDepositProposal)) {
             // Testing all expected object properties
             assert.property(depositProposal, expectedProperty, `property: ${expectedProperty} does not exist in depositRecord`);
@@ -320,14 +320,14 @@ contract('Bridge - [createDepositProposal with relayerThreshold > 1]', async (ac
 
     it("depositProposal shouldn't be created if it doesn't have Inactive or Denied status", async () => {
         await truffleAssert.passes(BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
         ));
 
         await truffleAssert.reverts(BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
@@ -336,25 +336,25 @@ contract('Bridge - [createDepositProposal with relayerThreshold > 1]', async (ac
 
     it('originChainRelayerAddress should be marked as voted for proposal', async () => {
         await BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
         );
-        const hasVoted = await BridgeInstance.hasVoted(originChainID, expectedDepositID, originChainRelayerAddress);
+        const hasVoted = await BridgeInstance.hasVoted(destinationChainID, expectedDepositID, originChainRelayerAddress);
         assert.isTrue(hasVoted);
     });
 
     it('DepositProposalCreated event is fired with expected value', async () => {
         const proposalTx = await BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }
         );
 
         truffleAssert.eventEmitted(proposalTx, 'DepositProposalCreated', (event) => {
-            return event.originChainID.toNumber() === originChainID &&
+            return event.destinationChainID.toNumber() === destinationChainID &&
                 event.depositID.toNumber() === expectedDepositID &&
                 event.dataHash === dataHash
         });
@@ -362,7 +362,7 @@ contract('Bridge - [createDepositProposal with relayerThreshold > 1]', async (ac
 
     it('getDepositProposal should return correct values in expected order', async () => {
         const expectedDepositProposal = {
-            _originChainID: originChainID,
+            _destinationChainID: destinationChainID,
             _depositID: expectedDepositID,
             _dataHash: dataHash,
             _numYes: 1,
@@ -371,7 +371,7 @@ contract('Bridge - [createDepositProposal with relayerThreshold > 1]', async (ac
         };
 
         await BridgeInstance.createDepositProposal(
-            originChainID,
+            destinationChainID,
             expectedDepositID,
             dataHash,
             { from: originChainRelayerAddress }


### PR DESCRIPTION
For #203 

Added

-In  `Bridge.sol`:
    - `getCentrifugeAssetDepositRecord` method
    - `depositCentrifugeAsset` method
    - `CentrifugeAssetDeposited` event
- `ICentrifugeAssetHandler.sol`
- `CentrifugeAssetHandler.sol`

Updated use of `originChainID` for accessing/create `depositProposal`s as a temporary fix for #173 while PR #200 is still being worked on:

---

@ansermino @GregTheGreek In [the example](https://gist.github.com/mikiquantum/3f4b59953a2ef999623797800e1d0237) that David provided, there's an `assetStored` event, do we need that to be emitted in `executeDeposit`? Is there anything else that's missing?