### PR TITLE
Update and rename PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,20 +2,11 @@
  Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
 -->
 
-<!-- Please begin the title of this PR with a list of the packages touched (eg. "cmd, rpc: Add Literal Bells and Whistles") -->
-
-
 <!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
 ## Changes
 - 
 - 
 - 
-
-<!-- Details on how to run only the tests for the changes in the PR -->
-## Tests:
-```
-
-```
 
 <!-- Issues that this PR will close -->
 <!-- 
@@ -23,4 +14,4 @@
     eg: 'closes #1 and closes #2'
     See: https://help.github.com/en/articles/closing-issues-using-keywords
 -->
-### Issues:
+#### Closes: #?


### PR DESCRIPTION
Fairly self-explanatory. This should automatically configure it as the template for future PRs.